### PR TITLE
[ci skip] Fix Jenkins link and remove modrinth pending approval tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ After installing the plugin, use the following commands in-game or from the serv
 If you encounter any issues or have suggestions for improvements, please file an issue on the [GitHub Issues page](https://github.com/Evidentsinger14/PermissionPurge/issues).
 
 ## Downloads
-| Platform | Link                                                                             | Badges                                                                                                                |
-|----------|----------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
-| Modrinth | [Download Link](https://modrinth.com/plugin/permissionpurge/) (Pending Approval) | ![Modrinth Downloads](https://img.shields.io/modrinth/dt/permissionpurge)                                             |
-| Jenkins  | [Download Link](https://ci.ev1dent.dev/job/MetaTokens/)                          | [![Build Status](https://ci.ev1dent.dev/job/PermissionPurge/badge/icon)](https://ci.ev1dent.dev/job/PermissionPurge/) |
+| Platform | Link                                                                            | Badges                                                                                                                |
+|----------|---------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------|
+| Modrinth | [Download Link](https://modrinth.com/plugin/permissionpurge/)  | ![Modrinth Downloads](https://img.shields.io/modrinth/dt/permissionpurge)                                             |
+| Jenkins  | [Download Link](https://ci.ev1dent.dev/job/PermissionPurge/)                         | [![Build Status](https://ci.ev1dent.dev/job/PermissionPurge/badge/icon)](https://ci.ev1dent.dev/job/PermissionPurge/) |
 
 ## Contributing
 Contributions to `PermissionPurge` are welcome! If you would like to contribute, please fork the repository and submit a pull request with your changes.


### PR DESCRIPTION
Jenkins masked link was previously pointing to [MetaTokens](https://ci.ev1dent.dev/job/MetaTokens/) instead of [PermissionPurge](https://ci.ev1dent.dev/job/PermissionPurge/), and plugin's no longer pending an approval on [Modrinth](https://modrinth.com/plugin/permissionpurge) thus removing the "(Pending Approval)" tag. 